### PR TITLE
feat: add support for wide for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # ecs-cli
-**Note: This cli is still under development**  
-Simple kubectl like CLI tool for AWS Elastic Container Service.
+A kubectl-style command-line interface for AWS Elastic Container Service (ECS) that simplifies cluster management and container operations.
+
+Important: This CLI is designed to interact with existing ECS clusters and services. It does NOT create or manage AWS infrastructure resources. For infrastructure provisioning, please use AWS CLI, AWS CloudFormation, or Terraform. While task deletion is supported, service deletion has many implications (load balancers, auto-scaling groups, task definitions) and is intentionally not supported. 
+
+## Features
+- Context-based configuration management similar to kubectl  
+- Easy service and task management for existing ECS resources  
+- Real-time container logs viewing  
+- Service scaling capabilities  
+- AWS profile and region support  
+- Intuitive command structure
+
+## Scope
+### What this CLI does:
+
+- Manage and switch between multiple ECS cluster contexts  
+- List and describe existing services and tasks  
+- View and follow container logs  
+- Scale existing services  
+
+### What this CLI doesn't do:
+- Create or delete ECS clusters  
+- Create or modify AWS infrastructure  
+- Manage IAM roles or permissions  
+- Handle service definitions or task definitions  
+- Manage Auto Scaling configurations  
+- Create or modify Load Balancers  
 
 ## Installation 
 ### Using Binary
@@ -12,20 +37,38 @@ chmod +x ecs
 mv ecs /usr/local/bin/
 ecs version
 ```
-
-## Supported commands
+### Building from Source
+```bash
+git clone https://github.com/yogendratamanga48/ecs-cli.git
+cd ecs-cli
+go build -o ecs
+mv ecs /usr/local/bin/
 ```
-# get help
-ecs --help
-# Context setup 
-ecs config set-context default --cluster default --profile airflow --region us-east-1  
-
-# view contexts
-ecs config get-contexts
-
+## Configuration
+The CLI uses a context-based configuration system similar to kubectl, powered by Viper. Configurations are stored in `$HOME/.ecs/config.yaml` 
+## Context Management
+setup new context:
+```bash
+ecs config set-context <my-context> \
+    --cluster <my-cluster> \
+    --profile <aws-profile> \
+    --region <region>
+```
+Other context operations:
+```bash
+ecs config get contexts
+ecs config use-context <context-name>
+ecs config delete-context <context-name>
+```
+## Usage
+```bash
 # get service and tasks
-ecs get services
 ecs get tasks
+ecs get services -o json
+ecs get tasks -o wide
+
+# delete task
+ecs delete task <task-id>
 
 # Describe Service and Tasks
 ecs describe service <service-name>
@@ -38,3 +81,12 @@ ecs logs <task-id> --follow
 # scale service
 ecs scale service-name --replicas=N
 ```
+
+## Development
+This CLI is built using:
+- [Cobra](https://github.com/spf13/cobra) - CLI framework  
+- [Viper](https://github.com/spf13/viper) - Configuration management  
+- [pflag](https://github.com/spf13/pflag) - Flag parsing  
+
+## Status
+Note: This CLI is under active development. Breaking changes may occur.

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -202,7 +202,7 @@ Examples:
 					return fmt.Errorf("failed to list tasks: %w", err)
 				}
 				for _, task := range tasks {
-					taskIds = append(taskIds, task.TaskARN)
+					taskIds = append(taskIds, task.TaskArn)
 				}
 			}
 
@@ -231,13 +231,13 @@ Examples:
 			default:
 				// Default formatted output
 				for _, task := range tasks {
-					fmt.Printf("Task ID:          %s\n", task.TaskID)
+					fmt.Printf("Task ID:          %s\n", task.TaskId)
 					fmt.Printf("Status:           %s\n", task.Status)
 					fmt.Printf("Desired Status:   %s\n", task.DesiredStatus)
-					fmt.Printf("Task Definition:  %s\n", task.TaskDefinitionARN)
+					fmt.Printf("Task Definition:  %s\n", task.TaskDefinitionArn)
 					fmt.Printf("Launch Type:      %s\n", task.LaunchType)
-					if task.CPU != "" {
-						fmt.Printf("CPU:             %s\n", task.CPU)
+					if task.Cpu != "" {
+						fmt.Printf("CPU:             %s\n", task.Cpu)
 					}
 					if task.Memory != "" {
 						fmt.Printf("Memory:          %s\n", task.Memory)

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -118,7 +118,7 @@ func getServicesCmd() *cobra.Command {
 	}
 
 	// Add flags
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (json|yaml)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (json|yaml|wide)")
 
 	return cmd
 }
@@ -151,6 +151,42 @@ func getTasksCmd() *cobra.Command {
 
 			// Handle different output formats
 			switch outputFormat {
+			case "wide":
+				headers := []string{
+					"TASK ID",
+					"STATUS",
+					"TASK DEFINITION",
+					"STARTED",
+					"AGE",
+					"CPU",
+					"MEMORY",
+					"LAUNCH TYPE",
+					"CAPACITY PROVIDER",
+				}
+				table := utils.NewTableFormatter(headers)
+				for _, task := range tasks {
+					age := time.Since(task.CreatedAt).Round(time.Second)
+					started := "-"
+					if !task.StartedAt.IsZero() {
+						started = formatAge(time.Since(task.StartedAt))
+					}
+
+					row := []string{
+						task.TaskId,
+						task.Status,
+						task.TaskDefFamily,
+						started,
+						formatAge(age),
+						task.Cpu,
+						task.Memory,
+						task.LaunchType,
+						"-",
+					}
+					table.AppendRow(row)
+				}
+
+				table.Render()
+				return nil
 			case "json":
 				data, err := json.MarshalIndent(tasks, "", "  ")
 				if err != nil {
@@ -187,7 +223,7 @@ func getTasksCmd() *cobra.Command {
 					}
 
 					row := []string{
-						task.TaskID,
+						task.TaskId,
 						task.Status,
 						task.TaskDefFamily,
 						started,
@@ -206,7 +242,7 @@ func getTasksCmd() *cobra.Command {
 	}
 
 	// Add flags
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (json|yaml)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (json|yaml|wide)")
 
 	return cmd
 }

--- a/pkg/aws/task.go
+++ b/pkg/aws/task.go
@@ -48,16 +48,24 @@ func (c *ECSClient) ListTasks(ctx context.Context) ([]*types.Task, error) {
 
 			taskDefParts := strings.Split(*task.TaskDefinitionArn, "/")
 			taskDefFamily := taskDefParts[len(taskDefParts)-1]
-
 			t := &types.Task{
-				TaskID:        taskId,
-				TaskARN:       *task.TaskArn,
+				TaskId:        taskId,
+				TaskArn:       *task.TaskArn,
 				Status:        string(*task.LastStatus),
 				TaskDefFamily: taskDefFamily,
 				LastStatus:    string(*task.LastStatus),
 				DesiredStatus: string(*task.DesiredStatus),
 				CreatedAt:     *task.CreatedAt,
 				Group:         *task.Group,
+				Cpu:           *task.Cpu,
+				Memory:        *task.Memory,
+				LaunchType:    string(task.LaunchType),
+				CapacityProvider: func() string {
+					if task.CapacityProviderName != nil {
+						return string(*task.CapacityProviderName)
+					}
+					return "-"
+				}(),
 			}
 
 			if task.StartedAt != nil {
@@ -65,7 +73,7 @@ func (c *ECSClient) ListTasks(ctx context.Context) ([]*types.Task, error) {
 			}
 
 			if task.ContainerInstanceArn != nil {
-				t.ContainerInstanceARN = *task.ContainerInstanceArn
+				t.ContainerInstanceArn = *task.ContainerInstanceArn
 			}
 
 			tasks = append(tasks, t)
@@ -95,23 +103,31 @@ func (c *ECSClient) DescribeTasks(ctx context.Context, taskIds []string) ([]*typ
 
 	for _, task := range result.Tasks {
 		taskDetail := &types.TaskDetail{
-			TaskID:            extractTaskId(*task.TaskArn),
-			TaskARN:           *task.TaskArn,
-			ClusterARN:        *task.ClusterArn,
-			TaskDefinitionARN: *task.TaskDefinitionArn,
+			TaskId:            extractTaskId(*task.TaskArn),
+			TaskArn:           *task.TaskArn,
+			ClusterArn:        *task.ClusterArn,
+			Cpu:               *task.Cpu,
+			Memory:            *task.Memory,
+			TaskDefinitionArn: *task.TaskDefinitionArn,
 			Status:            string(*task.LastStatus),
 			DesiredStatus:     string(*task.DesiredStatus),
 			CreatedAt:         *task.CreatedAt,
 			Group:             *task.Group,
 			LaunchType:        string(task.LaunchType),
+			CapacityProvider: func() string {
+				if task.CapacityProviderName != nil {
+					return string(*task.CapacityProviderName)
+				}
+				return "-"
+			}(),
 		}
 
 		if task.ContainerInstanceArn != nil {
-			taskDetail.ContainerInstanceARN = *task.ContainerInstanceArn
+			taskDetail.ContainerInstanceArn = *task.ContainerInstanceArn
 		}
 
 		if task.Cpu != nil {
-			taskDetail.CPU = *task.Cpu
+			taskDetail.Cpu = *task.Cpu
 		}
 
 		if task.Memory != nil {

--- a/pkg/types/task.go
+++ b/pkg/types/task.go
@@ -4,14 +4,18 @@ package types
 import "time"
 
 type Task struct {
-	TaskID               string    `json:"taskId" yaml:"taskId"`
-	TaskARN              string    `json:"taskArn" yaml:"taskArn"`
+	TaskId               string    `json:"taskId" yaml:"taskId"`
+	TaskArn              string    `json:"taskArn" yaml:"taskArn"`
 	Status               string    `json:"status" yaml:"status"`
+	Cpu                  string    `json:"cpu" yaml:"cpu"`
+	Memory               string    `json:"memory" yaml:"memory"`
+	LaunchType           string    `json:"launchType" yaml:"launchType"`
 	TaskDefFamily        string    `json:"taskDefinitionFamily" yaml:"taskDefinitionFamily"`
 	LastStatus           string    `json:"lastStatus" yaml:"lastStatus"`
 	DesiredStatus        string    `json:"desiredStatus" yaml:"desiredStatus"`
 	CreatedAt            time.Time `json:"createdAt" yaml:"createdAt"`
 	StartedAt            time.Time `json:"startedAt" yaml:"startedAt"`
 	Group                string    `json:"group" yaml:"group"`
-	ContainerInstanceARN string    `json:"containerInstanceArn" yaml:"containerInstanceArn"`
+	ContainerInstanceArn string    `json:"containerInstanceArn" yaml:"containerInstanceArn"`
+	CapacityProvider     string    `json:"capacityProvider" yaml:"capacityProvider"`
 }

--- a/pkg/types/task_detail.go
+++ b/pkg/types/task_detail.go
@@ -6,14 +6,14 @@ import (
 )
 
 type TaskDetail struct {
-	TaskID               string             `json:"taskId" yaml:"taskId"`
-	TaskARN              string             `json:"taskArn" yaml:"taskArn"`
-	ClusterARN           string             `json:"clusterArn" yaml:"clusterArn"`
-	TaskDefinitionARN    string             `json:"taskDefinitionArn" yaml:"taskDefinitionArn"`
-	ContainerInstanceARN string             `json:"containerInstanceArn,omitempty" yaml:"containerInstanceArn,omitempty"`
+	TaskId               string             `json:"taskId" yaml:"taskId"`
+	TaskArn              string             `json:"taskArn" yaml:"taskArn"`
+	ClusterArn           string             `json:"clusterArn" yaml:"clusterArn"`
+	TaskDefinitionArn    string             `json:"taskDefinitionArn" yaml:"taskDefinitionArn"`
+	ContainerInstanceArn string             `json:"containerInstanceArn,omitempty" yaml:"containerInstanceArn,omitempty"`
 	Status               string             `json:"status" yaml:"status"`
 	DesiredStatus        string             `json:"desiredStatus" yaml:"desiredStatus"`
-	CPU                  string             `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	Cpu                  string             `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	Memory               string             `json:"memory,omitempty" yaml:"memory,omitempty"`
 	CreatedAt            time.Time          `json:"createdAt" yaml:"createdAt"`
 	StartedAt            time.Time          `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
@@ -23,6 +23,7 @@ type TaskDetail struct {
 	LaunchType           string             `json:"launchType" yaml:"launchType"`
 	Containers           []ContainerDetail  `json:"containers" yaml:"containers"`
 	NetworkInterfaces    []NetworkInterface `json:"networkInterfaces,omitempty" yaml:"networkInterfaces,omitempty"`
+	CapacityProvider     string             `json:"capacityProvider,omitempty" yaml:"capacityProvider,omitempty"`
 }
 
 type ContainerDetail struct {


### PR DESCRIPTION
Added support for the -o wide option to the get tasks command. This displays additional details about tasks, including CPU, memory allocation, launch type, and capacity provider